### PR TITLE
even faster hexToDec

### DIFF
--- a/src/LiveData.cpp
+++ b/src/LiveData.cpp
@@ -176,17 +176,16 @@ void LiveData::initParams()
 double LiveData::hexToDec(String hexString, uint8_t bytes, bool signedNum)
 {
   uint64_t range;
-  double decValue = strtoll(hexString.c_str(), NULL, 16);
-  if (signedNum)
-  {
-    range = pow(256, bytes);
+  if (bytes < 1 || bytes > 4)
+    return -1;
+
+  double decValue = strtoul(hexString.c_str(), NULL, 16);
+  if (signedNum) {
+    range = ((uint64_t) 1) << (bytes*8);
     if (decValue > (range - 1) / 2)
       decValue -= range;
   }
-  if (bytes < 1 || bytes > 4)
-    return -1;
-  else
-    return decValue;
+  return decValue;
 }
 
 /**


### PR DESCRIPTION
`strtoul` (32-bit) is faster than `strtoll` (64-bit) and enough in this function.
`pow` is a very slow function. If range is uint64_t, bit shifting is much faster.

Here are the benchmarks I've run on the M5 Core2:

```
using strtoul and bit shifting:
signed: 1, string:FFAABBCC, hexToDec:-5588020.0 newHexToDec: -5588020.0, improvement: 36.4
signed: 0, string:FFAABBCC, hexToDec:4289379276.0 newHexToDec: 4289379276.0, improvement: 36.0
signed: 1, string:FFAABB, hexToDec:-21829.0 newHexToDec: -21829.0, improvement: 28.1
signed: 0, string:FFAABB, hexToDec:16755387.0 newHexToDec: 16755387.0, improvement: 29.9
signed: 1, string:FFAA, hexToDec:-86.0 newHexToDec: -86.0, improvement: 22.3
signed: 0, string:FFAA, hexToDec:65450.0 newHexToDec: 65450.0, improvement: 22.9
signed: 1, string:FA, hexToDec:-6.0 newHexToDec: -6.0, improvement: 2.3
signed: 0, string:FA, hexToDec:250.0 newHexToDec: 250.0, improvement: 2.7

using strtoul and pow:
signed: 1, string:FFAABBCC, hexToDec:-5588020.0 newHexToDec: -5588020.0, improvement: 8.2
signed: 0, string:FFAABBCC, hexToDec:4289379276.0 newHexToDec: 4289379276.0, improvement: 34.5
signed: 1, string:FFAABB, hexToDec:-21829.0 newHexToDec: -21829.0, improvement: 6.2
signed: 0, string:FFAABB, hexToDec:16755387.0 newHexToDec: 16755387.0, improvement: 28.3
signed: 1, string:FFAA, hexToDec:-86.0 newHexToDec: -86.0, improvement: 15.6
signed: 0, string:FFAA, hexToDec:65450.0 newHexToDec: 65450.0, improvement: 20.6
signed: 1, string:FA, hexToDec:-6.0 newHexToDec: -6.0, improvement: 1.9
signed: 0, string:FA, hexToDec:250.0 newHexToDec: 250.0, improvement: 2.7

using strtoll and bit shifting:
signed: 1, string:FFAABBCC, hexToDec:-5588020.0 newHexToDec: -5588020.0, improvement: 24.3
signed: 0, string:FFAABBCC, hexToDec:4289379276.0 newHexToDec: 4289379276.0, improvement: 25.1
signed: 1, string:FFAABB, hexToDec:-21829.0 newHexToDec: -21829.0, improvement: 19.2
signed: 0, string:FFAABB, hexToDec:16755387.0 newHexToDec: 16755387.0, improvement: 20.6
signed: 1, string:FFAA, hexToDec:-86.0 newHexToDec: -86.0, improvement: 14.6
signed: 0, string:FFAA, hexToDec:65450.0 newHexToDec: 65450.0, improvement: 15.4
signed: 1, string:FA, hexToDec:-6.0 newHexToDec: -6.0, improvement: 1.8
signed: 0, string:FA, hexToDec:250.0 newHexToDec: 250.0, improvement: 1.9
```