### PR TITLE
Changed remoteUploadAbrpIntervalSec

### DIFF
--- a/src/Board320_240.cpp
+++ b/src/Board320_240.cpp
@@ -2359,7 +2359,7 @@ void Board320_240::menuItemClick()
       return;
       break;
     case MENU_REMOTE_UPLOAD_ABRP_INTERVAL:
-      liveData->settings.remoteUploadAbrpIntervalSec = (liveData->settings.remoteUploadAbrpIntervalSec == 120) ? 0 : liveData->settings.remoteUploadAbrpIntervalSec + 10;
+      liveData->settings.remoteUploadAbrpIntervalSec = (liveData->settings.remoteUploadAbrpIntervalSec == 30) ? 0 : liveData->settings.remoteUploadAbrpIntervalSec + 2; // Better with smaller steps and maximum 30 seconds
       liveData->settings.remoteUploadIntervalSec = 0;
       showMenu();
       return;


### PR DESCRIPTION
Changed remoteUploadAbrpIntervalSec from maximum 120 sec, and change in 10 sec steps to maximum 30 sec and 2 sec steps because its more reasonable due to maximum update interval according to ABRP API is 10 sec and normally more often is better.